### PR TITLE
Compatibility aver gnome-shell 3.38

### DIFF
--- a/indicators/bluetooth.js
+++ b/indicators/bluetooth.js
@@ -95,7 +95,11 @@ var BluetoothIndicator = new Lang.Class({
         let sensitive = !Main.sessionMode.isLocked && !Main.sessionMode.isGreeter;
         this.menu.setSensitive(sensitive);
 
-        let [nDevices, nConnectedDevices] = this._bluetooth._getNDevices();
+        let adapter = this._bluetooth._getDefaultAdapter();
+	let devices = this._bluetooth._getDeviceInfos(adapter);
+        let connectedDevices = devices.filter(dev => dev.connected);
+        let nConnectedDevices = connectedDevices.length;
+        let nDevices = devices.length;
 
         if (nConnectedDevices > 0) {
             // Paired

--- a/indicators/system.js
+++ b/indicators/system.js
@@ -52,7 +52,8 @@ var UserIndicator = new Lang.Class({
         this._powerIcon = new St.Icon({ gicon: this._power_gicon });
         this._powerIcon.icon_size = PANEL_ICON_SIZE;
 
-        this.box.add_child(this._screencast);
+        if (this._screencast)
+             this.box.add_child(this._screencast);
         this.box.add_child(this._powerIcon);
         this.box.add_child(this._nameLabel);
 


### PR DESCRIPTION
The bluetooth and system indicator was not working anymore. This is just due to the version of gnome-shell 